### PR TITLE
Add unit tests for TL module and fix some bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ rsa.pub
 # emacs auto-saving files
 \#*#
 .#*#
+.#*

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,10 @@ rsa.pub
 \#*#
 .#*#
 .#*
+
+# tmp files
+tmp
+full_TL_schema.JSON
+
+# git config
+.gitignore

--- a/TL.py
+++ b/TL.py
@@ -63,7 +63,7 @@ class TL:
 
 
 ## Loading TL_schema (should be placed in the same directory as mtproto.py
-tl = TL(os.path.join(os.path.dirname(__file__), "TL_schema.JSON"))
+tl = TL(os.path.join(os.path.abspath(os.path.dirname(__file__)), "TL_schema.JSON"))
 
 
 def serialize_obj(type_, **kwargs):

--- a/mtproto.py
+++ b/mtproto.py
@@ -130,6 +130,7 @@ class Session:
         return data
 
     def method_call(self, method, **kwargs):
+        print 'call %s' % method
         for i in range(1, self.MAX_RETRY):
             try:
                 self.send_message(TL.serialize_method(method, **kwargs))

--- a/testing.py
+++ b/testing.py
@@ -19,9 +19,11 @@ if not config.read('credentials'):
 ip = config.get('App data', 'ip_address')
 port = config.getint('App data', 'port')
 
+api_id = config.getint('App data', 'api_id')
+api_hash = config.get('App data', 'api_hash')
+
 Session = mtproto.Session(ip, port)
 
 Session.create_auth_key()
-
 future_salts = Session.method_call('get_future_salts', num=3)
 print(future_salts)

--- a/tests/TL_test.py
+++ b/tests/TL_test.py
@@ -1,0 +1,51 @@
+import io
+import unittest
+from binascii import unhexlify
+
+import TL
+from Crypto.Hash import SHA
+
+class TLTest(unittest.TestCase):
+
+    def test_serialize_method(self):
+        """Test sample from [https://core.telegram.org/mtproto/samples-auth_key#1-request-for-p-q-authorization]"""
+        nonce = unhexlify('3E0549828CCA27E966B301A48FECE2FC')
+        serialized_result = TL.serialize_method('req_pq', nonce=nonce)
+        true_result = unhexlify('789746603E0549828CCA27E966B301A48FECE2FC')
+        self.assertEqual(serialized_result, true_result)
+
+    def test_serialize_object(self):
+        """Test sample from https://core.telegram.org/mtproto/samples-auth_key#4-encrypted-data-generation"""
+        pq = unhexlify('17ED48941A08F981')
+        p = unhexlify('494C553B')
+        q = unhexlify('53911073')
+        nonce = unhexlify('3E0549828CCA27E966B301A48FECE2FC')
+        server_nonce = unhexlify('A5CF4D33F4A11EA877BA4AA573907330')
+        new_nonce = unhexlify('311C85DB234AA2640AFC4A76A735CF5B1F0FD68BD17FA181E1229AD867CC024D')
+        serialized_result = TL.serialize_obj('p_q_inner_data',
+                                             pq=pq,
+                                             p=p,
+                                             q=q,
+                                             nonce=nonce,
+                                             server_nonce=server_nonce,
+                                             new_nonce=new_nonce)
+        SHA_result = SHA.new(serialized_result).digest()
+        true_result = unhexlify('db761c27718a2305044f71f2ad951629d78b2449')
+        self.assertEqual(SHA_result, true_result)
+
+    def test_deserialize(self):
+        response_bytes = io.BytesIO(unhexlify('632416053E0549828CCA27E966B301A48FECE2FCA5CF4D33F4A11EA877BA4AA5739073300817ED48941A08F98100000015C4B51C01000000216BE86C022BB4C3'))
+        deserialized_result = TL.deserialize(response_bytes)
+        true_result = {'nonce': unhexlify('3E0549828CCA27E966B301A48FECE2FC'),
+                       'server_nonce': unhexlify('A5CF4D33F4A11EA877BA4AA573907330'),
+                       'pq': unhexlify('17ED48941A08F981'),
+                       'server_public_key_fingerprints': [-4344800451088585951]}
+        self.assertDictEqual(true_result, deserialized_result)
+
+def suite():
+    tests = ['test_serialize_method', 'test_serialize_object', 'test_deserialize']
+    return unittest.TestSuite(map(TLTest, tests))
+
+if __name__ == '__main__':
+    # unittest.main()
+    unittest.TextTestRunner().run(suite())


### PR DESCRIPTION
## Changes
- Make the loading path of son file absolute
- Add unit tests for TL.serialize_method, TL.serialize_obj and TL.deserialize
- The test samples are from [**Creating an Authorization Key (Samples)**](https://core.telegram.org/mtproto/samples-auth_key#4-encrypted-data-generation)

## Issue
I choose [**nose**](https://nose.readthedocs.org/en/latest/) as the test tool and it works well with python2.7. However, using nose with python3 can be a little [troublesome](https://nose.readthedocs.org/en/latest/#python3). Of course, the unit tests themselves are okay for either py2 or py3 so you can run the tests in other way you like.